### PR TITLE
fixed scrollTo stimulus

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,9 @@
+// Load all the controllers within this directory and all subdirectories.
+// Controller files must be named *_controller.js.
+
+import { Application } from "stimulus"
+import { definitionsFromContext } from "stimulus/webpack-helpers"
+
+const application = Application.start()
+const context = require.context("controllers", true, /_controller\.js$/)
+application.load(definitionsFromContext(context))

--- a/app/javascript/controllers/scroll_to.js
+++ b/app/javascript/controllers/scroll_to.js
@@ -1,0 +1,5 @@
+import { Application } from "stimulus"
+import ScrollTo from "stimulus-scroll-to"
+
+const application = Application.start()
+application.register("scroll-to", ScrollTo)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -24,14 +24,10 @@ require("channels")
 
 // External imports
 import "bootstrap";
+import "controllers"
 
 // Internal imports, e.g:
 // import { initSelect2 } from '../components/init_select2';
-import { Application } from "stimulus"
-import ScrollTo from "stimulus-scroll-to"
-
-const application = Application.start()
-application.register("scroll-to", ScrollTo)
 
 document.addEventListener('turbolinks:load', () => {
   // Call your functions here, e.g:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bootstrap": "4.6",
     "jquery": "^3.6.0",
     "popper.js": "^1.16.1",
+    "stimulus": "^3.0.0",
     "stimulus-checkbox-select-all": "^4.0.0",
     "stimulus-scroll-to": "^3.0.0",
     "turbolinks": "^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -890,6 +890,11 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
+"@hotwired/stimulus@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.0.0.tgz#45171e61417af60f0e546665c52fae5b67295cee"
+  integrity sha512-UFIuuf7GjKJoIYromuTmqfzT8gZ8eu5zIB5m2QoEsopymGeN7rfDSTRPyRfwHIqP0x+0vWo4O1LFozw+/sWXxg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -7028,6 +7033,13 @@ stimulus-scroll-to@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/stimulus-scroll-to/-/stimulus-scroll-to-3.0.0.tgz#e30ceaffe5c524d1f767f5be4bac6bffa9925b2c"
   integrity sha512-0YMISBjkSxkT57/TR0blxMtz6GuHmolph+kLocIH5ptW03wM032r6y24qGhd2FKt+MJyDHPAdxFkidLf1WG5eQ==
+
+stimulus@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-3.0.0.tgz#90f7a7bc62e57f3852adaf33c01fea5f80401142"
+  integrity sha512-vINtZ6C43PWIqAv04oE/gKdfFPbVlWdClPUegFeAg1dTJABuzFTcnIOufgbMNAQQHFJeEhcgcLtEeiwtyYzNlg==
+  dependencies:
+    "@hotwired/stimulus" "^3.0.0"
 
 stream-browserify@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
received email from heroku saying "Field 'browser' doesn't contain a valid alias configuration
                     /tmp/build_bc8767fe/node_modules/stimulus doesn't exist
                   .mjs"

installed rails webpacker:install:stimulus, scrollTo function is still working. 