### PR TITLE
remove dup const in app.js

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -30,16 +30,11 @@ import "controllers"
 // import { initSelect2 } from '../components/init_select2';
 import { Application } from "stimulus"
 import ScrollTo from "stimulus-scroll-to"
-
-const application = Application.start()
-application.register("scroll-to", ScrollTo)
-
-import { Application } from "stimulus"
 import CheckboxSelectAll from "stimulus-checkbox-select-all"
 
 const application = Application.start()
+application.register("scroll-to", ScrollTo)
 application.register("checkbox-select-all", CheckboxSelectAll)
-
 
 document.addEventListener('turbolinks:load', () => {
   // Call your functions here, e.g:


### PR DESCRIPTION
received error msg from heroku: "Identifier 'application' has already been declared"

removed import { Application } from "stimulus" and const application = Application.start()
