### PR TITLE
remove migrations for product and user id for ratings table

### DIFF
--- a/, 
+++ b/, 
@@ -1,0 +1,290 @@
+=> {[33m:category[0m=>
+  [[31m[1;31m"[0m[31mVideo Games[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mXbox 360[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mAccessories[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mControllers[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mJoysticks[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31m</span></span></span>[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mOriginal PCB used from Xbox 360 Control Pad (to ensure 100% compatibility)[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mFULL SIZE MAS STICK[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mSpecial Design for Xbox 360 (Street Fighter Button Layout)[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mUses USB port of your Xbox 360 (not wireless),Works with PC games as well[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mPerfect 360 Optical Stick by HAPP (used in most U.S. Arcades)[1;31m"[0m[31m[0m],
+ [33m:tech1[0m=>[31m[1;31m"[0m[31m[1;31m"[0m[31m[0m,
+ [33m:description[0m=>
+  [[31m[1;31m"[0m[31mMAS's Pro Xbox 360 Stick (Perfect 360 Stick) SF Style White/Green Overlay[1;31m"[0m[31m[0m],
+ [33m:fit[0m=>[31m[1;31m"[0m[31m[1;31m"[0m[31m[0m,
+ [33m:title[0m=>[31m[1;31m"[0m[31mXbox 360 MAS STICK[1;31m"[0m[31m[0m,
+ [33m:also_buy[0m=>[],
+ [33m:tech2[0m=>[31m[1;31m"[0m[31m[1;31m"[0m[31m[0m,
+ [33m:brand[0m=>[31m[1;31m"[0m[31mby[1;35m\n[0m[31m    [1;35m\n[0m[31m    MAS SYSTEMS[1;31m"[0m[31m[0m,
+ [33m:feature[0m=>
+  [[31m[1;31m"[0m[31mOriginal PCB used from Xbox 360 Control Pad (to ensure 100% compatibility)[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mFULL SIZE MAS STICK[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mSpecial Design for Xbox 360 (Street Fighter Button Layout)[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mUses USB port of your Xbox 360 (not wireless),Works with PC games as well[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mPerfect 360 Optical Stick by HAPP (used in most U.S. Arcades)[1;31m"[0m[31m[0m],
+ [33m:rank[0m=>
+  [[31m[1;31m"[0m[31m>#105,263 in Video Games (See Top 100 in Video Games)[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31m>#56 in Video Games &gt; Xbox 360 &gt; Accessories &gt; Controllers &gt; Joysticks[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31m>#70,640 in Video Games &gt; Accessories[1;31m"[0m[31m[0m],
+ [33m:also_view[0m=>[],
+ [33m:main_cat[0m=>[31m[1;31m"[0m[31mVideo Games[1;31m"[0m[31m[0m,
+ [33m:similar_item[0m=>[31m[1;31m"[0m[31m[1;31m"[0m[31m[0m,
+ [33m:date[0m=>[31m[1;31m"[0m[31m[1;31m"[0m[31m[0m,
+ [33m:price[0m=>[31m[1;31m"[0m[31m[1;31m"[0m[31m[0m,
+ [33m:asin[0m=>[31m[1;31m"[0m[31m0324411812[1;31m"[0m[31m[0m,
+ [33m:imageURL[0m=>
+  [[31m[1;31m"[0m[31mhttps://images-na.ssl-images-amazon.com/images/I/51oaA-KAaiL._AC_SX150_SY75_CR,0,0,150,75_.jpg[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mhttps://images-na.ssl-images-amazon.com/images/I/51oaA-KAaiL._AC_SX150_SY75_CR,0,0,150,75_.jpg[1;31m"[0m[31m[0m],
+ [33m:imageURLHighRes[0m=>
+  [[31m[1;31m"[0m[31mhttps://images-na.ssl-images-amazon.com/images/I/51oaA-KAaiL.jpg[1;31m"[0m[31m[0m,
+   [31m[1;31m"[0m[31mhttps://images-na.ssl-images-amazon.com/images/I/51oaA-KAaiL.jpg[1;31m"[0m[31m[0m]}
+
+                   SSUUMMMMAARRYY OOFF LLEESSSS CCOOMMMMAANNDDSS
+
+      Commands marked with * may be preceded by a number, _N.
+      Notes in parentheses indicate the behavior if _N is given.
+      A key preceded by a caret indicates the Ctrl key; thus ^K is ctrl-K.
+
+  h  H                 Display this help.
+  q  :q  Q  :Q  ZZ     Exit.
+ ---------------------------------------------------------------------------
+
+                           MMOOVVIINNGG
+
+  e  ^E  j  ^N  CR  *  Forward  one line   (or _N lines).
+  y  ^Y  k  ^K  ^P  *  Backward one line   (or _N lines).
+  f  ^F  ^V  SPACE  *  Forward  one window (or _N lines).
+  b  ^B  ESC-v      *  Backward one window (or _N lines).
+  z                 *  Forward  one window (and set window to _N).
+  w                 *  Backward one window (and set window to _N).
+  ESC-SPACE         *  Forward  one window, but don't stop at end-of-file.
+  d  ^D             *  Forward  one half-window (and set half-window to _N).
+  u  ^U             *  Backward one half-window (and set half-window to _N).
+  ESC-)  RightArrow *  Right one half screen width (or _N positions).
+  ESC-(  LeftArrow  *  Left  one half screen width (or _N positions).
+  ESC-}  ^RightArrow   Right to last column displayed.
+  ESC-{  ^LeftArrow    Left  to first column.
+  F                    Forward forever; like "tail -f".
+  ESC-F                Like F but stop when search pattern is found.
+  r  ^R  ^L            Repaint screen.
+  R                    Repaint screen, discarding buffered input.
+        ---------------------------------------------------
+        Default "window" is the screen height.
+        Default "half-window" is half of the screen height.
+ ---------------------------------------------------------------------------
+
+                          SSEEAARRCCHHIINNGG
+
+  /_p_a_t_t_e_r_n          *  Search forward for (_N-th) matching line.
+  ?_p_a_t_t_e_r_n          *  Search backward for (_N-th) matching line.
+  n                 *  Repeat previous search (for _N-th occurrence).
+  N                 *  Repeat previous search in reverse direction.
+  ESC-n             *  Repeat previous search, spanning files.
+  ESC-N             *  Repeat previous search, reverse dir. & spanning files.
+  ESC-u                Undo (toggle) search highlighting.
+  &_p_a_t_t_e_r_n          *  Display only matching lines
+        ---------------------------------------------------
+        A search pattern may begin with one or more of:
+        ^N or !  Search for NON-matching lines.
+        ^E or *  Search multiple files (pass thru END OF FILE).
+        ^F or @  Start search at FIRST file (for /) or last file (for ?).
+        ^K       Highlight matches, but don't move (KEEP position).
+        ^R       Don't use REGULAR EXPRESSIONS.
+ ---------------------------------------------------------------------------
+
+                           JJUUMMPPIINNGG
+
+  g  <  ESC-<       *  Go to first line in file (or line _N).
+  G  >  ESC->       *  Go to last line in file (or line _N).
+  p  %              *  Go to beginning of file (or _N percent into file).
+  t                 *  Go to the (_N-th) next tag.
+  T                 *  Go to the (_N-th) previous tag.
+  {  (  [           *  Find close bracket } ) ].
+  }  )  ]           *  Find open bracket { ( [.
+  ESC-^F _<_c_1_> _<_c_2_>  *  Find close bracket _<_c_2_>.
+  ESC-^B _<_c_1_> _<_c_2_>  *  Find open bracket _<_c_1_> 
+        ---------------------------------------------------
+        Each "find close bracket" command goes forward to the close bracket 
+          matching the (_N-th) open bracket in the top line.
+        Each "find open bracket" command goes backward to the open bracket 
+          matching the (_N-th) close bracket in the bottom line.
+
+  m_<_l_e_t_t_e_r_>            Mark the current top line with <letter>.
+  M_<_l_e_t_t_e_r_>            Mark the current bottom line with <letter>.
+  '_<_l_e_t_t_e_r_>            Go to a previously marked position.
+  ''                   Go to the previous position.
+  ^X^X                 Same as '.
+  ESC-M_<_l_e_t_t_e_r_>        Clear a mark.
+        ---------------------------------------------------
+        A mark is any upper-case or lower-case letter.
+        Certain marks are predefined:
+             ^  means  beginning of the file
+             $  means  end of the file
+ ---------------------------------------------------------------------------
+
+                        CCHHAANNGGIINNGG FFIILLEESS
+
+  :e [_f_i_l_e]            Examine a new file.
+  ^X^V                 Same as :e.
+  :n                *  Examine the (_N-th) next file from the command line.
+  :p                *  Examine the (_N-th) previous file from the command line.
+  :x                *  Examine the first (or _N-th) file from the command line.
+  :d                   Delete the current file from the command line list.
+  =  ^G  :f            Print current file name.
+ ---------------------------------------------------------------------------
+
+                    MMIISSCCEELLLLAANNEEOOUUSS CCOOMMMMAANNDDSS
+
+  -_<_f_l_a_g_>              Toggle a command line option [see OPTIONS below].
+  --_<_n_a_m_e_>             Toggle a command line option, by name.
+  __<_f_l_a_g_>              Display the setting of a command line option.
+  ___<_n_a_m_e_>             Display the setting of an option, by name.
+  +_c_m_d                 Execute the less cmd each time a new file is examined.
+
+  !_c_o_m_m_a_n_d             Execute the shell command with $SHELL.
+  |XX_c_o_m_m_a_n_d            Pipe file between current pos & mark XX to shell command.
+  s _f_i_l_e               Save input to a file.
+  v                    Edit the current file with $VISUAL or $EDITOR.
+  V                    Print version number of "less".
+ ---------------------------------------------------------------------------
+
+                           OOPPTTIIOONNSS
+
+        Most options may be changed either on the command line,
+        or from within less by using the - or -- command.
+        Options may be given in one of two forms: either a single
+        character preceded by a -, or a name preceded by --.
+
+  -?  ........  --help
+                  Display help (from command line).
+  -a  ........  --search-skip-screen
+                  Search skips current screen.
+  -A  ........  --SEARCH-SKIP-SCREEN
+                  Search starts just after target line.
+  -b [_N]  ....  --buffers=[_N]
+                  Number of buffers.
+  -B  ........  --auto-buffers
+                  Don't automatically allocate buffers for pipes.
+  -c  ........  --clear-screen
+                  Repaint by clearing rather than scrolling.
+  -d  ........  --dumb
+                  Dumb terminal.
+  -D [_x_n_._n]  .  --color=_x_n_._n
+                  Set screen colors. (MS-DOS only)
+  -e  -E  ....  --quit-at-eof  --QUIT-AT-EOF
+                  Quit at end of file.
+  -f  ........  --force
+                  Force open non-regular files.
+  -F  ........  --quit-if-one-screen
+                  Quit if entire file fits on first screen.
+  -g  ........  --hilite-search
+                  Highlight only last match for searches.
+  -G  ........  --HILITE-SEARCH
+                  Don't highlight any matches for searches.
+  -h [_N]  ....  --max-back-scroll=[_N]
+                  Backward scroll limit.
+  -i  ........  --ignore-case
+                  Ignore case in searches that do not contain uppercase.
+  -I  ........  --IGNORE-CASE
+                  Ignore case in all searches.
+  -j [_N]  ....  --jump-target=[_N]
+                  Screen position of target lines.
+  -J  ........  --status-column
+                  Display a status column at left edge of screen.
+  -k [_f_i_l_e]  .  --lesskey-file=[_f_i_l_e]
+                  Use a lesskey file.
+  -K  ........  --quit-on-intr
+                  Exit less in response to ctrl-C.
+  -L  ........  --no-lessopen
+                  Ignore the LESSOPEN environment variable.
+  -m  -M  ....  --long-prompt  --LONG-PROMPT
+                  Set prompt style.
+  -n  -N  ....  --line-numbers  --LINE-NUMBERS
+                  Don't use line numbers.
+  -o [_f_i_l_e]  .  --log-file=[_f_i_l_e]
+                  Copy to log file (standard input only).
+  -O [_f_i_l_e]  .  --LOG-FILE=[_f_i_l_e]
+                  Copy to log file (unconditionally overwrite).
+  -p [_p_a_t_t_e_r_n]  --pattern=[_p_a_t_t_e_r_n]
+                  Start at pattern (from command line).
+  -P [_p_r_o_m_p_t]   --prompt=[_p_r_o_m_p_t]
+                  Define new prompt.
+  -q  -Q  ....  --quiet  --QUIET  --silent --SILENT
+                  Quiet the terminal bell.
+  -r  -R  ....  --raw-control-chars  --RAW-CONTROL-CHARS
+                  Output "raw" control characters.
+  -s  ........  --squeeze-blank-lines
+                  Squeeze multiple blank lines.
+  -S  ........  --chop-long-lines
+                  Chop (truncate) long lines rather than wrapping.
+  -t [_t_a_g]  ..  --tag=[_t_a_g]
+                  Find a tag.
+  -T [_t_a_g_s_f_i_l_e] --tag-file=[_t_a_g_s_f_i_l_e]
+                  Use an alternate tags file.
+  -u  -U  ....  --underline-special  --UNDERLINE-SPECIAL
+                  Change handling of backspaces.
+  -V  ........  --version
+                  Display the version number of "less".
+  -w  ........  --hilite-unread
+                  Highlight first new line after forward-screen.
+  -W  ........  --HILITE-UNREAD
+                  Highlight first new line after any forward movement.
+  -x [_N[,...]]  --tabs=[_N[,...]]
+                  Set tab stops.
+  -X  ........  --no-init
+                  Don't use termcap init/deinit strings.
+  -y [_N]  ....  --max-forw-scroll=[_N]
+                  Forward scroll limit.
+  -z [_N]  ....  --window=[_N]
+                  Set size of window.
+  -" [_c[_c]]  .  --quotes=[_c[_c]]
+                  Set shell quote characters.
+  -~  ........  --tilde
+                  Don't display tildes after end of file.
+  -# [_N]  ....  --shift=[_N]
+                  Horizontal scroll amount (0 = one half screen width)
+                --follow-name
+                  The F command changes files if the input file is renamed.
+                --mouse
+                  Enable mouse input.
+                --no-keypad
+                  Don't send termcap keypad init/deinit strings.
+                --no-histdups
+                  Remove duplicates from command history.
+                --rscroll=C
+                  Set the character used to mark truncated lines.
+                --save-marks
+                  Retain marks across invocations of less.
+                --use-backslash
+                  Subsequent options use backslash as escape char.
+                --wheel-lines=N
+                  Each click of the mouse wheel moves N lines.
+
+
+ ---------------------------------------------------------------------------
+
+                          LLIINNEE EEDDIITTIINNGG
+
+        These keys can be used to edit text being entered 
+        on the "command line" at the bottom of the screen.
+
+ RightArrow ..................... ESC-l ... Move cursor right one character.
+ LeftArrow ...................... ESC-h ... Move cursor left one character.
+ ctrl-RightArrow  ESC-RightArrow  ESC-w ... Move cursor right one word.
+ ctrl-LeftArrow   ESC-LeftArrow   ESC-b ... Move cursor left one word.
+ HOME ........................... ESC-0 ... Move cursor to start of line.
+ END ............................ ESC-$ ... Move cursor to end of line.
+ BACKSPACE ................................ Delete char to left of cursor.
+ DELETE ......................... ESC-x ... Delete char under cursor.
+ ctrl-BACKSPACE   ESC-BACKSPACE ........... Delete word to left of cursor.
+ ctrl-DELETE .... ESC-DELETE .... ESC-X ... Delete word under cursor.
+ ctrl-U ......... ESC (MS-DOS only) ....... Delete entire line.
+ UpArrow ........................ ESC-k ... Retrieve previous command line.
+ DownArrow ...................... ESC-j ... Retrieve next command line.
+ TAB ...................................... Complete filename & cycle.
+ SHIFT-TAB ...................... ESC-TAB   Complete filename & reverse cycle.
+ ctrl-L ................................... Complete filename, list all.
+
+

--- a/db/migrate/20210929024144_add_user_to_ratings.rb
+++ b/db/migrate/20210929024144_add_user_to_ratings.rb
@@ -1,5 +1,0 @@
-class AddUserToRatings < ActiveRecord::Migration[6.0]
-  def change
-    add_reference :ratings, :user, foreign_key: true
-  end
-end

--- a/db/migrate/20210929025654_remove_and_add_columns_to_ratings.rb
+++ b/db/migrate/20210929025654_remove_and_add_columns_to_ratings.rb
@@ -1,6 +1,0 @@
-class RemoveAndAddColumnsToRatings < ActiveRecord::Migration[6.0]
-  def change
-    remove_reference :ratings, :orders
-    add_reference :ratings, :product
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-
-ActiveRecord::Schema.define(version: 2021_09_28_101640) do
-
-=======
-ActiveRecord::Schema.define(version: 2021_09_29_024144) do
->>>>>>> remove migration for recipient id, add migration for user id to ratings
-=======
 ActiveRecord::Schema.define(version: 2021_09_29_031758) do
->>>>>>> implement disco  gem and can display results on gift sessions view
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -153,8 +143,8 @@ ActiveRecord::Schema.define(version: 2021_09_29_031758) do
     t.string "description"
     t.string "image_url"
     t.string "brand"
+    t.integer "price_cents", default: 0, null: false
     t.decimal "average_rating", precision: 2, scale: 1
-    t.integer "price_cents", default: 0, null: fals
     t.index ["category_id"], name: "index_products_on_category_id"
   end
 
@@ -169,11 +159,15 @@ ActiveRecord::Schema.define(version: 2021_09_29_031758) do
 
   create_table "ratings", force: :cascade do |t|
     t.integer "rating"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
     t.bigint "product_id"
+    t.bigint "gift_session_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "recipient_id"
+    t.index ["gift_session_id"], name: "index_ratings_on_gift_session_id"
     t.index ["product_id"], name: "index_ratings_on_product_id"
+    t.index ["recipient_id"], name: "index_ratings_on_recipient_id"
     t.index ["user_id"], name: "index_ratings_on_user_id"
   end
 
@@ -218,8 +212,10 @@ ActiveRecord::Schema.define(version: 2021_09_29_031758) do
   add_foreign_key "orders", "products"
   add_foreign_key "orders", "users"
   add_foreign_key "products", "categories"
-  add_foreign_key "ratings", "users"
+  add_foreign_key "ratings", "gift_sessions"
   add_foreign_key "ratings", "products"
+  add_foreign_key "ratings", "users"
+  add_foreign_key "ratings", "users", column: "recipient_id"
   add_foreign_key "response_sets", "answers"
   add_foreign_key "response_sets", "questions"
   add_foreign_key "response_sets", "users"

--- a/sible_questions = @all_questions.reject do |question|
+++ b/sible_questions = @all_questions.reject do |question|
@@ -1,0 +1,126 @@
+=> [[32m#<Question:0x000055a4280db228[0m
+  id: [1;34m1[0m,
+  content: [31m[1;31m"[0m[31mDo you have a pet?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m1[0m,
+  dependency: [1;34m0[0m[32m>[0m,
+ [32m#<Question:0x000055a4280b7e90[0m
+  id: [1;34m2[0m,
+  content: [31m[1;31m"[0m[31mDo you enjoy dressing your pet up?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m1[0m[32m>[0m,
+ [32m#<Question:0x000055a4280b7d50[0m
+  id: [1;34m3[0m,
+  content:
+   [31m[1;31m"[0m[31mWhich of these toys does your pet enjoy playing with?[1;31m"[0m[31m[0m,
+  options:
+   [[31m[1;31m"[0m[31mSoft Toy[1;31m"[0m[31m[0m,
+    [31m[1;31m"[0m[31mChew Toy[1;31m"[0m[31m[0m,
+    [31m[1;31m"[0m[31mFeather on a stick[1;31m"[0m[31m[0m,
+    [31m[1;31m"[0m[31mBone[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m1[0m[32m>[0m,
+ [32m#<Question:0x000055a4280b7c38[0m
+  id: [1;34m4[0m,
+  content: [31m[1;31m"[0m[31mDo you exercise with your pet?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m1[0m[32m>[0m,
+ [32m#<Question:0x000055a4280b7b70[0m
+  id: [1;34m5[0m,
+  content:
+   [31m[1;31m"[0m[31mDo you enjoy doing outdoor activities?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m2[0m,
+  dependency: [1;34m0[0m[32m>[0m,
+ [32m#<Question:0x000055a4280b7aa8[0m
+  id: [1;34m6[0m,
+  content:
+   [31m[1;31m"[0m[31mDo you feel more at ease on land, at sea, or in air?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mland[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31msea[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mair[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m2[0m[32m>[0m,
+ [32m#<Question:0x000055a4280b79e0[0m
+  id: [1;34m7[0m,
+  content: [31m[1;31m"[0m[31mDo you enjoy group activities?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m1[0m,
+  dependency: [1;34m2[0m[32m>[0m]
+=> [[32m#<Question:0x00007fc794a53878[0m
+  id: [1;34m1[0m,
+  content: [31m[1;31m"[0m[31mDo you have a pet?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m1[0m,
+  dependency: [1;34m0[0m[32m>[0m,
+ [32m#<Question:0x00007fc794a303f0[0m
+  id: [1;34m2[0m,
+  content: [31m[1;31m"[0m[31mDo you enjoy dressing your pet up?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m1[0m[32m>[0m,
+ [32m#<Question:0x00007fc794a30328[0m
+  id: [1;34m3[0m,
+  content:
+   [31m[1;31m"[0m[31mWhich of these toys does your pet enjoy playing with?[1;31m"[0m[31m[0m,
+  options:
+   [[31m[1;31m"[0m[31mSoft Toy[1;31m"[0m[31m[0m,
+    [31m[1;31m"[0m[31mChew Toy[1;31m"[0m[31m[0m,
+    [31m[1;31m"[0m[31mFeather on a stick[1;31m"[0m[31m[0m,
+    [31m[1;31m"[0m[31mBone[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m1[0m[32m>[0m,
+ [32m#<Question:0x00007fc794a30260[0m
+  id: [1;34m4[0m,
+  content: [31m[1;31m"[0m[31mDo you exercise with your pet?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m1[0m[32m>[0m,
+ [32m#<Question:0x00007fc794a30198[0m
+  id: [1;34m5[0m,
+  content:
+   [31m[1;31m"[0m[31mDo you enjoy doing outdoor activities?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m2[0m,
+  dependency: [1;34m0[0m[32m>[0m,
+ [32m#<Question:0x00007fc794a300a8[0m
+  id: [1;34m6[0m,
+  content:
+   [31m[1;31m"[0m[31mDo you feel more at ease on land, at sea, or in air?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mland[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31msea[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mair[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m2[0m[32m>[0m,
+ [32m#<Question:0x00007fc794a2ff68[0m
+  id: [1;34m7[0m,
+  content: [31m[1;31m"[0m[31mDo you enjoy group activities?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m1[0m,
+  dependency: [1;34m2[0m[32m>[0m]

--- a/sible_questions.reject do |question|
+++ b/sible_questions.reject do |question|
@@ -1,0 +1,63 @@
+=> [[32m#<Question:0x000055a426781868[0m
+  id: [1;34m1[0m,
+  content: [31m[1;31m"[0m[31mDo you have a pet?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m1[0m,
+  dependency: [1;34m0[0m[32m>[0m,
+ [32m#<Question:0x00007fc794424560[0m
+  id: [1;34m2[0m,
+  content: [31m[1;31m"[0m[31mDo you enjoy dressing your pet up?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m1[0m[32m>[0m,
+ [32m#<Question:0x00007fc794424308[0m
+  id: [1;34m3[0m,
+  content:
+   [31m[1;31m"[0m[31mWhich of these toys does your pet enjoy playing with?[1;31m"[0m[31m[0m,
+  options:
+   [[31m[1;31m"[0m[31mSoft Toy[1;31m"[0m[31m[0m,
+    [31m[1;31m"[0m[31mChew Toy[1;31m"[0m[31m[0m,
+    [31m[1;31m"[0m[31mFeather on a stick[1;31m"[0m[31m[0m,
+    [31m[1;31m"[0m[31mBone[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m1[0m[32m>[0m,
+ [32m#<Question:0x000055a427813f28[0m
+  id: [1;34m4[0m,
+  content: [31m[1;31m"[0m[31mDo you exercise with your pet?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m1[0m[32m>[0m,
+ [32m#<Question:0x000055a427813d98[0m
+  id: [1;34m5[0m,
+  content:
+   [31m[1;31m"[0m[31mDo you enjoy doing outdoor activities?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m2[0m,
+  dependency: [1;34m0[0m[32m>[0m,
+ [32m#<Question:0x000055a427813b68[0m
+  id: [1;34m6[0m,
+  content:
+   [31m[1;31m"[0m[31mDo you feel more at ease on land, at sea, or in air?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mland[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31msea[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mair[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m2[0m[32m>[0m,
+ [32m#<Question:0x000055a4278139b0[0m
+  id: [1;34m7[0m,
+  content: [31m[1;31m"[0m[31mDo you enjoy group activities?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m1[0m,
+  dependency: [1;34m2[0m[32m>[0m]

--- a/sible_questions.reject! do |question|
+++ b/sible_questions.reject! do |question|
@@ -1,0 +1,63 @@
+=> [[32m#<Question:0x00007fc794321d48[0m
+  id: [1;34m1[0m,
+  content: [31m[1;31m"[0m[31mDo you have a pet?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m1[0m,
+  dependency: [1;34m0[0m[32m>[0m,
+ [32m#<Question:0x00007fc794321c80[0m
+  id: [1;34m2[0m,
+  content: [31m[1;31m"[0m[31mDo you enjoy dressing your pet up?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m1[0m[32m>[0m,
+ [32m#<Question:0x00007fc794321bb8[0m
+  id: [1;34m3[0m,
+  content:
+   [31m[1;31m"[0m[31mWhich of these toys does your pet enjoy playing with?[1;31m"[0m[31m[0m,
+  options:
+   [[31m[1;31m"[0m[31mSoft Toy[1;31m"[0m[31m[0m,
+    [31m[1;31m"[0m[31mChew Toy[1;31m"[0m[31m[0m,
+    [31m[1;31m"[0m[31mFeather on a stick[1;31m"[0m[31m[0m,
+    [31m[1;31m"[0m[31mBone[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m1[0m[32m>[0m,
+ [32m#<Question:0x00007fc794321af0[0m
+  id: [1;34m4[0m,
+  content: [31m[1;31m"[0m[31mDo you exercise with your pet?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m1[0m[32m>[0m,
+ [32m#<Question:0x00007fc794321780[0m
+  id: [1;34m5[0m,
+  content:
+   [31m[1;31m"[0m[31mDo you enjoy doing outdoor activities?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m2[0m,
+  dependency: [1;34m0[0m[32m>[0m,
+ [32m#<Question:0x00007fc794321618[0m
+  id: [1;34m6[0m,
+  content:
+   [31m[1;31m"[0m[31mDo you feel more at ease on land, at sea, or in air?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mland[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31msea[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mair[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m0[0m,
+  dependency: [1;34m2[0m[32m>[0m,
+ [32m#<Question:0x00007fc794321488[0m
+  id: [1;34m7[0m,
+  content: [31m[1;31m"[0m[31mDo you enjoy group activities?[1;31m"[0m[31m[0m,
+  options: [[31m[1;31m"[0m[31mYes[1;31m"[0m[31m[0m, [31m[1;31m"[0m[31mNo[1;31m"[0m[31m[0m],
+  created_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  updated_at: [1;34;4mSun[0m, [1;34m26[0m [1;34;4mSep[0m [1;34m2021[0m [1;34m12[0m:[1;34m25[0m:[1;34m31[0m [1;34;4mUTC[0m [1;34m+00[0m:[1;34m00[0m,
+  parent: [1;34m1[0m,
+  dependency: [1;34m2[0m[32m>[0m]


### PR DESCRIPTION
This pull request introduces the following:
- remove migration files that previously added product and user id to ratings table (conflicts)