### PR TITLE
delete extra migration that adds recipient id to ratings table

### DIFF
--- a/db/migrate/20210928101640_add_recipient_id_to_ratings.rb
+++ b/db/migrate/20210928101640_add_recipient_id_to_ratings.rb
@@ -1,6 +1,0 @@
-class AddRecipientIdToRatings < ActiveRecord::Migration[6.0]
-  def change
-    add_reference :ratings, :recipient
-    add_foreign_key :ratings, :users, column: :recipient_id, primary_key: :id
-  end
-end


### PR DESCRIPTION
Delete migration that adds recipient id to ratings table